### PR TITLE
Docs/trustless work implementation

### DIFF
--- a/Dev_Setup_Guide.md
+++ b/Dev_Setup_Guide.md
@@ -187,7 +187,7 @@ Auth format varies per protocol in ways that are not documented anywhere. This t
 | Soroswap | None | No auth required |
 | Phoenix | None | No auth required |
 | Aquarius | None | No auth required |
-| Trustless Work | `Authorization: x-api-key: your-api-key` | NO "Bearer" prefix. Raw key only. |
+| Trustless Work | `x-api-key: your-api-key` | NO "Bearer" prefix. Raw key only. |
 
 ### Etherfuse (correct)
 

--- a/Dev_Setup_Guide.md
+++ b/Dev_Setup_Guide.md
@@ -17,6 +17,7 @@
 | Reflector Oracle | No | -- | -- | -- |
 | BlindPay | Yes (sandbox) | Self-service at app.blindpay.com | Instant | https://app.blindpay.com |
 | AlfredPay | Yes (sandbox) | Public sandbox keys in docs | Instant | See below |
+| Trustless Work | Yes | Self-service via docs | Instant | https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key |
 
 
 ### Etherfuse
@@ -51,6 +52,13 @@ Public sandbox credentials from the AlfredPay docs — shared and intended for a
 1. Sign up at https://app.blindpay.com
 2. Create a free "Development instance"
 3. Generate API keys for that instance
+
+
+### Trustless Work
+
+- **React SDK env var:** `NEXT_PUBLIC_API_KEY`
+- **Auth:** `Authorization: x-api-key: your-api-key`
+- **Self-service signup:** https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
 
 
 ## Section 2: Testnet Contract Addresses
@@ -121,6 +129,15 @@ Aquarius does not publish a static contract address list. Use the testnet app to
 Contract addresses are listed at https://reflector.network/oracles — use the mainnet/testnet toggle in the upper-right.
 
 
+### Trustless Work (testnet)
+
+Verified from the Trustless Work registry.
+
+| Contract | Address | Verified |
+|---|---|---|
+| multi-release Escrow | `CB7EYMEHZI3UWS3EHNOUI55OD6X5FLMV537NEUQ6EWO677N6B6XSBP25` | Yes |
+| single-release Escrow | `CDHAZ2RTE2MDHYQQ7NATF5IVKIFVGLX6FHJ66OPK6MUXBSTRRXFXJ6QB` | Yes |
+
 > Testnet contracts get redeployed periodically. If an address stops working, check the source links above for updated values.
 
 
@@ -169,6 +186,7 @@ Auth format varies per protocol in ways that are not documented anywhere. This t
 | Soroswap | None | No auth required |
 | Phoenix | None | No auth required |
 | Aquarius | None | No auth required |
+| Trustless Work | `Authorization: x-api-key: your-api-key` | NO "Bearer" prefix. Raw key only. |
 
 ### Etherfuse (correct)
 
@@ -184,6 +202,15 @@ headers: {
 ```typescript
 headers: {
   'Authorization': `Bearer ${process.env.DEFINDEX_API_KEY}`,
+  'Content-Type': 'application/json'
+}
+```
+
+### Trustless Work (correct)
+
+```typescript
+headers: {
+  'x-api-key': process.env.TRUSTLESS_WORK_API_KEY,
   'Content-Type': 'application/json'
 }
 ```
@@ -464,6 +491,26 @@ Use `rpc.Server` (Soroban RPC) as your primary server for all operations — sma
 ### WebAuthn passkeys: rpId must be a domain, not an IP address
 
 WebAuthn rejects IP addresses as the `rpId`. If your browser connects via `127.0.0.1`, explicitly force `rpId` to `'localhost'`. Never use `192.168.x.x` or bare IP addresses for local development.
+
+
+### Trustless Work: Role Trustline Requirement
+
+Each role involved must establish a trustline for the asset being used to create the escrow before the escrow is initialized.
+
+
+### Trustless Work: Restrictions when escrow is funded
+
+The platform role is the only role authorized to modify the escrow at any time. However, once the escrow holds a balance, modifications are restricted exclusively to adding milestones, and no other properties can be updated.
+
+
+### Trustless Work: Trustline Requirement
+
+The trustline address must be the issuer address (starting with 'G'), not the contract ID.
+
+
+### Trustless Work: Dispute Resolver Restriction
+
+The dispute resolver address must be unique.
 
 
 ## Section 6: Known Limitations, and What to Ask Your DevRel Mentor

--- a/Dev_Setup_Guide.md
+++ b/Dev_Setup_Guide.md
@@ -56,7 +56,8 @@ Public sandbox credentials from the AlfredPay docs — shared and intended for a
 
 ### Trustless Work
 
-- **React SDK env var:** `NEXT_PUBLIC_API_KEY`
+- **React SDK env var (client):** `NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY`
+- **Server env var (Node / headers):** `TRUSTLESS_WORK_API_KEY`
 - **Auth:** `Authorization: x-api-key: your-api-key`
 - **Self-service signup:** https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
 

--- a/Dev_Setup_Guide.md
+++ b/Dev_Setup_Guide.md
@@ -58,7 +58,7 @@ Public sandbox credentials from the AlfredPay docs — shared and intended for a
 
 - **React SDK env var (client):** `NEXT_PUBLIC_TRUSTLESS_WORK_API_KEY`
 - **Server env var (Node / headers):** `TRUSTLESS_WORK_API_KEY`
-- **Auth:** `Authorization: x-api-key: your-api-key`
+- **Auth:** `x-api-key: your-api-key`
 - **Self-service signup:** https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
 
 

--- a/Hackathon_Resources.md
+++ b/Hackathon_Resources.md
@@ -23,7 +23,7 @@ Everything you need before writing a line of code. For the full reference (API k
 - **Soroswap:** no key needed on testnet
 - **DeFindex:** self-service signup at https://docs.defindex.io/api-integration-guide/api#generate-your-api-key
 - **BlindPay / AlfredPay:** check their respective docs for sandbox access
-- **Trustless Work:** self-service https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
+- **Trustless Work:** self-service at https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
 
 ### Things Worth Knowing Upfront
 

--- a/Hackathon_Resources.md
+++ b/Hackathon_Resources.md
@@ -23,6 +23,7 @@ Everything you need before writing a line of code. For the full reference (API k
 - **Soroswap:** no key needed on testnet
 - **DeFindex:** self-service signup at https://docs.defindex.io/api-integration-guide/api#generate-your-api-key
 - **BlindPay / AlfredPay:** check their respective docs for sandbox access
+- **Trustless Work:** self-service https://docs.trustlesswork.com/trustless-work/introduction/developer-resources/request-api-key
 
 ### Things Worth Knowing Upfront
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ The fastest way to avoid the most common Claude mistake at a hackathon: building
 
 Everything you need before writing code, in one place.
 
-**API keys:** All protocols that require a key have self-service signup. Etherfuse: https://devnet.etherfuse.com/ramp. DeFindex, AlfredPay, and BlindPay: see Dev_Setup_Guide.md Section 1. Soroswap, Phoenix, Aquarius, and Blend require no key.
+**API keys:** All protocols that require a key have self-service signup. Etherfuse: https://devnet.etherfuse.com/ramp. DeFindex, AlfredPay, BlindPay and Trustless Work: see Dev_Setup_Guide.md Section 1. Soroswap, Phoenix, Aquarius, and Blend require no key.
 
-**Testnet contract addresses:** Verified DeFindex, Soroswap, and Blend addresses are included. Aquarius and Reflector Oracle link to their live registries. Phoenix is the only protocol still TBD.
+**Testnet contract addresses:** Verified DeFindex, Soroswap, Blend and Trustless Work addresses are included. Aquarius and Reflector Oracle link to their live registries. Phoenix is the only protocol still TBD.
 
-**Auth patterns:** This is where most developers lose time. Etherfuse uses `Authorization: your-api-key` with no Bearer prefix. DeFindex uses `Authorization: Bearer your-api-key`. They're opposites and neither is documented clearly. The guide has correct code snippets for both.
+**Auth patterns:** This is where most developers lose time. Etherfuse uses `Authorization: your-api-key` with no Bearer prefix. DeFindex uses `Authorization: Bearer your-api-key`. Trustless Work uses `x-api-key: your-api-key`. They're opposites and none are documented clearly. The guide has correct code snippets for all three.
 
 **Testnet asset registry:** Testnet USDC has multiple issuers that don't share liquidity; pick the wrong one and swaps silently fail. The guide covers all three (Circle, Blend, and Etherfuse — each separate), plus all five Etherfuse stablebond assets (CETES, USTRY, KTB, CARN, CZERO) with their testnet and mainnet issuer addresses.
 
@@ -59,6 +59,10 @@ Everything you need before writing code, in one place.
 - `sendTransaction` returns PENDING, not success: you need to poll (or use `rpc.Server.pollTransaction`)
 - DeFindex: classic Stellar assets must be SAC-deployed before depositing into vaults (all common ones already are)
 - DeFindex: the endpoint is `/vault/` not `/vaults/`, amounts are always arrays, success is HTTP 201
+- Trustless Work: Each role involved must establish a trustline for the asset being used to create the escrow before the escrow is initialized.
+- Trustless Work: The platform role is the only role authorized to modify the escrow at any time. However, once the escrow holds a balance, modifications are restricted exclusively to adding milestones, and no other properties can be updated.
+- Trustless Work: The trustline address must be the issuer address (starting with 'G'), not the contract ID.
+- Trustless Work: The dispute resolver address must be unique.
 
 **Section 6** covers known limitations and what to ask your DevRel mentor about, including undocumented API behaviors and known quirks.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Everything you need before writing code, in one place.
 
 **Testnet contract addresses:** Verified DeFindex, Soroswap, Blend and Trustless Work addresses are included. Aquarius and Reflector Oracle link to their live registries. Phoenix is the only protocol still TBD.
 
-**Auth patterns:** This is where most developers lose time. Etherfuse uses `Authorization: your-api-key` with no Bearer prefix. DeFindex uses `Authorization: Bearer your-api-key`. Trustless Work uses `x-api-key: your-api-key`. They're opposites and none are documented clearly. The guide has correct code snippets for all three.
+**Auth patterns:** This is where most developers lose time. Etherfuse uses `Authorization: your-api-key` with no Bearer prefix. DeFindex uses `Authorization: Bearer your-api-key`. Trustless Work uses `Authorization: x-api-key: your-api-key`. They're opposites and none are documented clearly. The guide has correct code snippets for all three.
 
 **Testnet asset registry:** Testnet USDC has multiple issuers that don't share liquidity; pick the wrong one and swaps silently fail. The guide covers all three (Circle, Blend, and Etherfuse — each separate), plus all five Etherfuse stablebond assets (CETES, USTRY, KTB, CARN, CZERO) with their testnet and mainnet issuer addresses.
 

--- a/Starter_Prompts.md
+++ b/Starter_Prompts.md
@@ -96,7 +96,7 @@ Create a `CLAUDE.md` at your repo root with this content. Every Claude Code sess
 - Endpoint is /vault/ not /vaults/; amounts are always arrays; success is HTTP 201
 
 ### Trustless Work
-- Auth header: `Authorization: x-api-key: your-api-key`
+- Auth header: `x-api-key: your-api-key`
 - API URL: [mainnet: https://api.trustlesswork.com | dev: https://dev.api.trustlesswork.com]
 
 ## Wallet architecture

--- a/Starter_Prompts.md
+++ b/Starter_Prompts.md
@@ -95,6 +95,10 @@ Create a `CLAUDE.md` at your repo root with this content. Every Claude Code sess
 - Classic Stellar assets must be SAC-deployed before depositing into vaults (all common ones already are)
 - Endpoint is /vault/ not /vaults/; amounts are always arrays; success is HTTP 201
 
+### Trustless Work
+- Auth header: `Authorization: x-api-key: your-api-key`
+- API URL: [mainnet: api.trustlesswork.com | dev.api.trustlesswork.com]
+
 ## Wallet architecture
 [Delete this section if not building a self-custodial wallet]
 - Self-custodial: generates BIP-39 mnemonic in-browser, no browser extension

--- a/Starter_Prompts.md
+++ b/Starter_Prompts.md
@@ -97,7 +97,7 @@ Create a `CLAUDE.md` at your repo root with this content. Every Claude Code sess
 
 ### Trustless Work
 - Auth header: `Authorization: x-api-key: your-api-key`
-- API URL: [mainnet: api.trustlesswork.com | dev.api.trustlesswork.com]
+- API URL: [mainnet: https://api.trustlesswork.com | dev: https://dev.api.trustlesswork.com]
 
 ## Wallet architecture
 [Delete this section if not building a self-custodial wallet]


### PR DESCRIPTION
## 📚 Docs: Trustless Work Resources Update

Closes #2

### Summary

This PR updates documentation with **Trustless Work (TW) information** across key areas:

- Hackathon resources
- Developer setup guide
- README
- Starter prompts

---

### 🎯 Purpose

- Provide clearer onboarding for developers
- Improve accessibility of TW resources
- Standardize documentation across entry points